### PR TITLE
Typo: `styles.css` -> `style.css`

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Perfect.
 
 ## Add some color
 
-Save the following styles to "styles.css" in the "static" folder.
+Save the following styles to "style.css" in the "static" folder.
 
 ```css
 body            { font-family: sans-serif; background: #eee; }


### PR DESCRIPTION
Tutorial instructions tell us to make a `styles.css` file when all other references use `style.css`.
